### PR TITLE
Add feedback agent, remove agent: block from SKILL.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,6 @@ The YAML frontmatter has these required sections:
 | `name` | Must match the folder name and email prefix |
 | `description` | One-sentence summary of the agent |
 | `metadata` | `author` (your GitHub username) and `version` |
-| `agent` | Public profile: `address`, `displayName`, `tagline`, `modes`, `capabilities` |
 | `config` | Runtime settings — see [Config reference](README.md#config-reference) in the README |
 | `variables` | Declares every `{variable}` your prompt and assets expect |
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To create a new agent, copy `_template/` and follow the instructions inside. See
 
 The `SKILL.md` file follows the [Agent Skills specification](https://agentskills.io/specification):
 
-- **YAML frontmatter**: `name`, `description`, `metadata`, `agent`, `config`, and `variables`
+- **YAML frontmatter**: `name`, `description`, `metadata`, `config`, and `variables`
 - **Markdown body**: The system prompt passed directly to the LLM
 
 The prompt contains `{variable}` placeholders that are interpolated at runtime (see below).
@@ -41,7 +41,6 @@ The prompt contains `{variable}` placeholders that are interpolated at runtime (
 | `name` | Agent identifier — must match the folder name and email prefix |
 | `description` | One-sentence description of the agent |
 | `metadata` | `author` and `version` |
-| `agent` | Public profile: `address`, `displayName`, `tagline`, `modes`, `capabilities` |
 | `config` | Runtime configuration consumed by the platform (see below) |
 | `variables` | Declares every `{variable}` the agent's files expect (see below) |
 

--- a/_template/SKILL.md
+++ b/_template/SKILL.md
@@ -14,23 +14,6 @@ metadata:
   author: your-github-username
   version: "1.0"
 
-# ── Agent profile (shown to users) ───────────────────────────────────────────
-agent:
-  address: my-agent@ainbox.io           # Must match folder name
-  displayName: aInbox My Agent          # Human-friendly name
-  tagline: Short one-liner shown in directories and help text.
-  modes:
-    # List each distinct way users interact with the agent.
-    # Key   = internal mode identifier (used by the platform)
-    # Value = one-line description shown to users
-    primary-mode: Describe what happens when the user forwards an email.
-    agent: Describe what happens when the user emails directly.
-  capabilities:
-    # Freeform tags — help the platform and users discover what this agent can do.
-    - capability-one
-    - capability-two
-    - multilingual
-
 # ── Runtime configuration (consumed by the aInbox platform) ──────────────────
 config:
   openaiModel: gpt-4.1-mini            # LLM model ID passed to the API

--- a/draft/SKILL.md
+++ b/draft/SKILL.md
@@ -8,20 +8,6 @@ metadata:
   author: verkyyi
   version: "1.1"
 
-agent:
-  address: draft@ainbox.io
-  displayName: aInbox Draft Agent
-  tagline: Tell me what to write. Get a ready-to-send draft.
-  modes:
-    reply-assist: Forward an email you received — get a draft reply you can send back.
-    draft: Email directly with a description of what you need written from scratch.
-  capabilities:
-    - email-drafting
-    - multilingual
-    - tone-adaptation
-    - iterative-refinement
-    - context-awareness
-
 config:
   openaiModel: gpt-4.1-mini
   maxCompletionTokens: 4096

--- a/feedback/SKILL.md
+++ b/feedback/SKILL.md
@@ -7,18 +7,6 @@ metadata:
   author: verkyyi
   version: "1.0"
 
-agent:
-  address: feedback@ainbox.io
-  displayName: aInbox Feedback
-  tagline: We read every message. Thank you for your feedback.
-  modes:
-    feedback: Acknowledges incoming feedback — categorizes it and confirms receipt.
-    agent: Handles questions about aInbox or the feedback process.
-  capabilities:
-    - feedback-collection
-    - multilingual
-    - auto-categorization
-
 config:
   openaiModel: gpt-4.1-mini
   maxCompletionTokens: 2048

--- a/summary/SKILL.md
+++ b/summary/SKILL.md
@@ -8,21 +8,6 @@ metadata:
   author: verkyyi
   version: "1.3"
 
-agent:
-  address: summary@ainbox.io
-  displayName: aInbox Summary Agent
-  tagline: Forward an email, get a summary. Or just say hello.
-  modes:
-    summarize: Processes forwarded emails — extracts key information and generates concise summaries.
-    agent: Handles direct emails — answers questions about aInbox, summarizes ad-hoc content, and guides new users.
-  capabilities:
-    - email-summarization
-    - multilingual
-    - phishing-detection
-    - image-understanding
-    - batch-processing
-    - direct-conversation
-
 config:
   openaiModel: gpt-4.1-mini
   maxCompletionTokens: 4096


### PR DESCRIPTION
## Summary

- Add `feedback/` agent skill — acknowledges user feedback, categorizes it, and forwards to the team
- Remove `agent:` block from all SKILL.md files (`summary`, `draft`, `feedback`, `_template`) — the server now derives agent metadata at load time from `name`, `description`, and template keys
- Update README.md and CONTRIBUTING.md to remove `agent` from frontmatter docs

Companion server PR: https://github.com/verkyyi/ainbox/pull/14

## Test plan

- [ ] Server loads all skills without errors after removing `agent:` blocks
- [ ] `GET /agent/summary` returns derived metadata
- [ ] `GET /api/agents` lists all three agents with correct derived taglines and modes
- [ ] Feedback agent processes incoming emails correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)