### PR TITLE
Strip redundant config from SKILL.md — overrides only

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ The YAML frontmatter has these required sections:
 | `name` | Must match the folder name and email prefix |
 | `description` | One-sentence summary of the agent |
 | `metadata` | `author` (your GitHub username) and `version` |
-| `config` | Runtime settings — see [Config reference](README.md#config-reference) in the README |
+| `config` | Runtime overrides only — omitted fields use server defaults. See [Config reference](README.md#config-reference) |
 | `variables` | Declares every `{variable}` your prompt and assets expect |
 
 ### templates.json

--- a/README.md
+++ b/README.md
@@ -46,24 +46,24 @@ The prompt contains `{variable}` placeholders that are interpolated at runtime (
 
 ## Config reference
 
-These fields in the `config:` block control how the platform runs the agent:
+The `config:` block only needs fields that differ from server defaults. Omitted fields use the defaults shown below. `fromEmail` and `fromName` are derived from the agent's folder name (e.g. `draft/` → `draft@ainbox.io`, `draft`).
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `openaiModel` | string | yes | LLM model ID passed to the API (e.g. `gpt-4.1-mini`) |
-| `maxCompletionTokens` | int | yes | Max tokens the LLM may generate per reply |
-| `temperature` | float\|null | no | Sampling temperature (`null` = model default) |
-| `maxBodyChars` | int | yes | Truncate inbound email body beyond this character limit |
-| `dailyLimit` | int | yes | Max requests per sender per calendar day (UTC) |
-| `fromEmail` | string | yes | Envelope-from address on outbound replies |
-| `fromName` | string | yes | Display name on outbound replies |
-| `feedbackEmail` | string | yes | Shown in error and rate-limit templates |
-| `fallbackForwardTo` | string | no | Forward unprocessable emails to this address (empty = discard) |
-| `autoReplyGuidance` | bool | no | Send a guidance reply when the agent can't determine the mode |
-| `allowedSenders` | string[] | no | Allowlist of sender addresses (empty = allow everyone) |
-| `blockedSenders` | string[] | no | Blocklist of sender addresses (checked before allowlist) |
-| `senderLimitOverrides` | object | no | Per-sender daily limit overrides, e.g. `{"vip@co.com": 100}` |
-| `dryRun` | bool | no | `true` = log replies but don't actually send them |
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `openaiModel` | string | `gpt-5` | LLM model ID passed to the API |
+| `maxCompletionTokens` | int | `4096` | Max tokens the LLM may generate per reply |
+| `temperature` | float\|null | `null` | Sampling temperature (`null` = model default) |
+| `maxBodyChars` | int | `24000` | Truncate inbound email body beyond this character limit |
+| `dailyLimit` | int | `50` | Max requests per sender per calendar day (UTC) |
+| `fromEmail` | string | `{name}@ainbox.io` | Envelope-from address on outbound replies |
+| `fromName` | string | `{name}` | Display name on outbound replies |
+| `feedbackEmail` | string | `feedback@ainbox.io` | Shown in error and rate-limit templates |
+| `fallbackForwardTo` | string | `""` | Forward unprocessable emails to this address (empty = discard) |
+| `autoReplyGuidance` | bool | `true` | Send a guidance reply when the agent can't determine the mode |
+| `allowedSenders` | string[] | `[]` | Allowlist of sender addresses (empty = allow everyone) |
+| `blockedSenders` | string[] | `[]` | Blocklist of sender addresses (checked before allowlist) |
+| `senderLimitOverrides` | object | `{}` | Per-sender daily limit overrides, e.g. `{"vip@co.com": 100}` |
+| `dryRun` | bool | `false` | `true` = log replies but don't actually send them |
 
 ## Variable contract
 

--- a/_template/SKILL.md
+++ b/_template/SKILL.md
@@ -14,22 +14,11 @@ metadata:
   author: your-github-username
   version: "1.0"
 
-# ── Runtime configuration (consumed by the aInbox platform) ──────────────────
+# ── Runtime configuration (overrides only — omitted fields use server defaults) ──
+# See README.md for all available fields and their defaults.
 config:
   openaiModel: gpt-4.1-mini            # LLM model ID passed to the API
-  maxCompletionTokens: 4096            # Max tokens the LLM may generate per reply
-  temperature: null                     # Sampling temperature (null = model default)
-  maxBodyChars: 24000                   # Truncate inbound email body beyond this limit
   dailyLimit: 30                        # Max requests per sender per calendar day
-  fromEmail: my-agent@ainbox.io         # Envelope-from on outbound replies
-  fromName: aInbox My Agent             # Display name on outbound replies
-  feedbackEmail: feedback@ainbox.io     # Shown in error/rate-limit templates
-  fallbackForwardTo: ""                 # Forward unprocessable emails here (empty = discard)
-  autoReplyGuidance: false              # Send a guidance reply when mode is unclear
-  allowedSenders: []                    # Allowlist — empty means everyone is allowed
-  blockedSenders: []                    # Blocklist — checked before allowlist
-  senderLimitOverrides: {}              # Per-sender daily limit overrides, e.g. {"vip@co.com": 100}
-  dryRun: false                         # true = log replies but don't send them
 
 # ── Variable contract ────────────────────────────────────────────────────────
 # Declare every {variable} your prompt and assets expect so the platform can

--- a/draft/SKILL.md
+++ b/draft/SKILL.md
@@ -10,19 +10,8 @@ metadata:
 
 config:
   openaiModel: gpt-4.1-mini
-  maxCompletionTokens: 4096
-  temperature: null
-  maxBodyChars: 24000
   dailyLimit: 30
-  fromEmail: draft@ainbox.io
-  fromName: aInbox Draft
-  feedbackEmail: feedback@ainbox.io
-  fallbackForwardTo: ""
   autoReplyGuidance: false
-  allowedSenders: []
-  blockedSenders: []
-  senderLimitOverrides: {}
-  dryRun: false
 
 variables:
   prompt:

--- a/feedback/SKILL.md
+++ b/feedback/SKILL.md
@@ -10,18 +10,9 @@ metadata:
 config:
   openaiModel: gpt-4.1-mini
   maxCompletionTokens: 2048
-  temperature: null
-  maxBodyChars: 24000
   dailyLimit: 10
-  fromEmail: feedback@ainbox.io
-  fromName: aInbox Feedback
-  feedbackEmail: feedback@ainbox.io
   fallbackForwardTo: verkyyi@gmail.com
   autoReplyGuidance: false
-  allowedSenders: []
-  blockedSenders: []
-  senderLimitOverrides: {}
-  dryRun: false
 
 variables:
   prompt:

--- a/summary/SKILL.md
+++ b/summary/SKILL.md
@@ -10,19 +10,6 @@ metadata:
 
 config:
   openaiModel: gpt-4.1-mini
-  maxCompletionTokens: 4096
-  temperature: null
-  maxBodyChars: 24000
-  dailyLimit: 50
-  fromEmail: summary@ainbox.io
-  fromName: aInbox
-  feedbackEmail: feedback@ainbox.io
-  fallbackForwardTo: ""
-  autoReplyGuidance: true
-  allowedSenders: []
-  blockedSenders: []
-  senderLimitOverrides: {}
-  dryRun: false
 
 variables:
   prompt:


### PR DESCRIPTION
## Summary

- Strip all config fields that match server defaults from `summary`, `draft`, `feedback`, and `_template` SKILL.md files
- summary: 14 fields → 1, draft: 14 → 3, feedback: 14 → 5, template: 14 → 2
- README config table updated with Default column showing what happens when a field is omitted
- CONTRIBUTING.md updated to note config is overrides-only

Companion server PR: https://github.com/verkyyi/ainbox/pull/15

## Test plan

- [ ] Server loads all skills correctly with minimal config blocks
- [ ] `fromEmail` and `fromName` derived correctly for each agent
- [ ] All existing functionality unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)