### PR TITLE
Remove unused variables: block from SKILL.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,6 @@ The YAML frontmatter has these required sections:
 | `description` | One-sentence summary of the agent |
 | `metadata` | `author` (your GitHub username) and `version` |
 | `config` | Runtime overrides only — omitted fields use server defaults. See [Config reference](README.md#config-reference) |
-| `variables` | Declares every `{variable}` your prompt and assets expect |
 
 ### templates.json
 
@@ -66,7 +65,7 @@ Each `.txt` file contains a sample email input and expected output, separated by
 
 ## Guidelines
 
-- **Preserve `{variable}` placeholders** — the app depends on them at runtime. Removing or renaming a placeholder will break things. Check the `variables:` section in SKILL.md to see which variables the agent declares.
+- **Preserve `{placeholder}` strings** — the app depends on them at runtime. Removing or renaming a placeholder will break things. See [Runtime variables](README.md#runtime-variables) for the full list.
 - **Keep prompts concise** — the LLM context window is shared with email content, so shorter prompts leave more room for the actual email.
 - **Follow the [Agent Skills spec](https://agentskills.io/specification)** — `SKILL.md` files must have valid YAML frontmatter.
 - **Support both EN and ZH** — templates are bilingual. If you update one language, please update the other too (or note in your PR that a translation is needed).
@@ -80,8 +79,7 @@ Each `.txt` file contains a sample email input and expected output, separated by
 3. Write your system prompt in the markdown body
 4. Customize `templates.json` for your agent's purpose
 5. Add 2-3 example emails in `examples/` covering the main modes
-6. Update the `variables:` block to declare every `{variable}` your files use
-7. Explain the agent's purpose and use case in your PR description
+6. Explain the agent's purpose and use case in your PR description
 
 Use the existing `summary/` and `draft/` agents as real-world references.
 

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ To create a new agent, copy `_template/` and follow the instructions inside. See
 
 The `SKILL.md` file follows the [Agent Skills specification](https://agentskills.io/specification):
 
-- **YAML frontmatter**: `name`, `description`, `metadata`, `config`, and `variables`
+- **YAML frontmatter**: `name`, `description`, `metadata`, and `config`
 - **Markdown body**: The system prompt passed directly to the LLM
 
-The prompt contains `{variable}` placeholders that are interpolated at runtime (see below).
+The prompt and templates contain `{placeholder}` strings that are interpolated at runtime (see below).
 
 ### Frontmatter sections
 
@@ -42,7 +42,6 @@ The prompt contains `{variable}` placeholders that are interpolated at runtime (
 | `description` | One-sentence description of the agent |
 | `metadata` | `author` and `version` |
 | `config` | Runtime configuration consumed by the platform (see below) |
-| `variables` | Declares every `{variable}` the agent's files expect (see below) |
 
 ## Config reference
 
@@ -65,25 +64,9 @@ The `config:` block only needs fields that differ from server defaults. Omitted 
 | `senderLimitOverrides` | object | `{}` | Per-sender daily limit overrides, e.g. `{"vip@co.com": 100}` |
 | `dryRun` | bool | `false` | `true` = log replies but don't actually send them |
 
-## Variable contract
-
-Each agent declares the `{variable}` placeholders it expects in a `variables:` block in its SKILL.md frontmatter. This serves as a contract between the agent and the platform:
-
-```yaml
-variables:
-  prompt:       # Variables used inside the system prompt (markdown body)
-    - dailyLimit
-  templates:    # Variables used inside assets/templates.json
-    - greeting
-    - summary
-    - tip
-```
-
-This makes each agent self-documenting and allows the platform to validate that all required variables are provided at runtime.
-
 ## Runtime variables
 
-These placeholders are replaced by the aInbox app at runtime:
+These `{placeholder}` strings are replaced by the aInbox app at runtime:
 
 ### In SKILL.md (system prompt)
 

--- a/_template/SKILL.md
+++ b/_template/SKILL.md
@@ -20,21 +20,6 @@ config:
   openaiModel: gpt-4.1-mini            # LLM model ID passed to the API
   dailyLimit: 30                        # Max requests per sender per calendar day
 
-# ── Variable contract ────────────────────────────────────────────────────────
-# Declare every {variable} your prompt and assets expect so the platform can
-# validate at load time and contributors know what's available.
-variables:
-  prompt:                               # Variables used inside the system prompt below
-    - dailyLimit
-  templates:                            # Variables used inside assets/templates.json
-    - greeting
-    - result
-    - tip
-    - originalSubject
-    - limit
-    - hoursLeft
-    - feedbackEmail
-
 ---
 
 You are aInbox My Agent, an AI email assistant at my-agent@ainbox.io.

--- a/draft/SKILL.md
+++ b/draft/SKILL.md
@@ -13,18 +13,6 @@ config:
   dailyLimit: 30
   autoReplyGuidance: false
 
-variables:
-  prompt:
-    - dailyLimit
-  templates:
-    - greeting
-    - summary
-    - tip
-    - originalSubject
-    - limit
-    - hoursLeft
-    - feedbackEmail
-
 ---
 
 You are aInbox Draft, an AI email drafting assistant at draft@ainbox.io. You help people write emails, replies, messages, and other written content.

--- a/feedback/SKILL.md
+++ b/feedback/SKILL.md
@@ -14,20 +14,6 @@ config:
   fallbackForwardTo: verkyyi@gmail.com
   autoReplyGuidance: false
 
-variables:
-  prompt:
-    - dailyLimit
-  templates:
-    - greeting
-    - summary
-    - tip
-    - originalSubject
-    - limit
-    - hoursLeft
-    - feedbackEmail
-  tips:
-    - dailyLimit
-    - feedbackEmail
 ---
 
 You are aInbox Feedback, the feedback handler at feedback@ainbox.io. You receive feedback from users about aInbox and respond with a warm acknowledgment.

--- a/summary/SKILL.md
+++ b/summary/SKILL.md
@@ -11,19 +11,6 @@ metadata:
 config:
   openaiModel: gpt-4.1-mini
 
-variables:
-  prompt:
-    - dailyLimit
-  templates:
-    - greeting
-    - summary
-    - tip
-    - originalSubject
-    - limit
-    - hoursLeft
-    - refSection
-    - feedbackEmail
-
 ---
 
 You are aInbox, an AI email assistant at summary@ainbox.io. You process incoming emails — either forwarded emails to summarize, or direct messages to respond to.


### PR DESCRIPTION
## Summary

- Remove `variables:` block from all SKILL.md files (summary, draft, feedback, _template)
- The block was never parsed or used by the server — interpolation is driven by `{placeholder}` strings in the prompt body and templates.json directly
- Update README.md and CONTRIBUTING.md to remove variable contract docs and references

## Test plan

- [x] `node test/test-llm-config.js` — 139/139 passed
- [x] `node test/test-batch-eml.js` — 33/33 passed
- [ ] Verify `{dailyLimit}` still interpolated in system prompt
- [ ] Verify `{greeting}`, `{summary}`, `{tip}` still work in templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)