### PR TITLE
Remove unused metadata parsing from skillLoader

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,6 @@ The YAML frontmatter has these required sections:
 |---------|---------|
 | `name` | Must match the folder name and email prefix |
 | `description` | One-sentence summary of the agent |
-| `metadata` | `author` (your GitHub username) and `version` |
 | `config` | Runtime overrides only — omitted fields use server defaults. See [Config reference](README.md#config-reference) |
 
 ### templates.json

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To create a new agent, copy `_template/` and follow the instructions inside. See
 
 The `SKILL.md` file follows the [Agent Skills specification](https://agentskills.io/specification):
 
-- **YAML frontmatter**: `name`, `description`, `metadata`, and `config`
+- **YAML frontmatter**: `name`, `description`, and `config`
 - **Markdown body**: The system prompt passed directly to the LLM
 
 The prompt and templates contain `{placeholder}` strings that are interpolated at runtime (see below).
@@ -40,7 +40,6 @@ The prompt and templates contain `{placeholder}` strings that are interpolated a
 |---------|---------|
 | `name` | Agent identifier — must match the folder name and email prefix |
 | `description` | One-sentence description of the agent |
-| `metadata` | `author` and `version` |
 | `config` | Runtime configuration consumed by the platform (see below) |
 
 ## Config reference

--- a/_template/SKILL.md
+++ b/_template/SKILL.md
@@ -10,10 +10,6 @@ name: my-agent                          # Folder name and email prefix (my-agent
 description: >
   One-sentence description of what this agent does when someone emails it.
 
-metadata:
-  author: your-github-username
-  version: "1.0"
-
 # ── Runtime configuration (overrides only — omitted fields use server defaults) ──
 # See README.md for all available fields and their defaults.
 config:

--- a/draft/SKILL.md
+++ b/draft/SKILL.md
@@ -4,10 +4,6 @@ description: >
   AI email drafting assistant at draft@ainbox.io. Forward an email to get a
   reply draft, or describe what you need written from scratch. Supports
   iterative refinement through follow-up replies.
-metadata:
-  author: verkyyi
-  version: "1.1"
-
 config:
   openaiModel: gpt-4.1-mini
   dailyLimit: 30

--- a/feedback/SKILL.md
+++ b/feedback/SKILL.md
@@ -3,10 +3,6 @@ name: feedback
 description: >
   Feedback handler at feedback@ainbox.io. Acknowledges user feedback,
   categorizes it, and forwards to the team.
-metadata:
-  author: verkyyi
-  version: "1.0"
-
 config:
   openaiModel: gpt-4.1-mini
   maxCompletionTokens: 2048

--- a/summary/SKILL.md
+++ b/summary/SKILL.md
@@ -4,10 +4,6 @@ description: >
   AI email assistant at summary@ainbox.io. Summarizes forwarded emails with
   categorization, phishing detection, and action items. Responds to direct
   emails as a conversational agent about aInbox.
-metadata:
-  author: verkyyi
-  version: "1.3"
-
 config:
   openaiModel: gpt-4.1-mini
 


### PR DESCRIPTION
## Summary

- Remove `metadata:` block (author, version) from all SKILL.md files
- Git history already tracks authorship and versioning
- Update README.md and CONTRIBUTING.md to remove metadata references

Companion server PR: https://github.com/verkyyi/ainbox/pull/16

## Test plan

- [x] `node test/test-llm-config.js` — 136/136 passed
- [x] `node test/test-batch-eml.js` — 33/33 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)