### PR TITLE
Strip utility templates, rely on server defaults

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,15 +48,17 @@ The YAML frontmatter has these required sections:
 
 ### templates.json
 
-Must contain all five template keys:
+Optional — only include mode templates that differ from server defaults. The server provides default templates for all utility messages (`error`, `rateLimit`, `guidance`, `bounce`, `ccNotSupported`) and generic mode templates (`result`, `agent`). Skill templates are merged on top of these defaults at load time.
+
+Most agents only need to customize mode templates with custom framing:
 
 | Key | Purpose | Shape |
 |-----|---------|-------|
 | `result` | Primary output (wraps LLM response) | `{ "en": "...", "zh": "..." }` |
 | `agent` | Direct email response | `{ "en": "...", "zh": "..." }` |
-| `guidance` | Sent when mode is unclear | `{ "subject": { ... }, "body": { ... } }` |
-| `error` | Sent on processing failure | `{ "subject": { ... }, "body": { ... } }` |
-| `rateLimit` | Sent when daily limit is reached | `{ "subject": { ... }, "body": { ... } }` |
+| Custom modes | Agent-specific modes (e.g. `reply-assist`, `draft`) | `{ "en": "...", "zh": "..." }` |
+
+Utility templates (`error`, `rateLimit`, `guidance`) are managed by server defaults and do **not** need to be included. Override them only if your agent needs different wording.
 
 ### examples/
 

--- a/_template/assets/templates.json
+++ b/_template/assets/templates.json
@@ -2,39 +2,5 @@
   "result": {
     "en": "{greeting}\n\n{result}\n\n{tip}",
     "zh": "{greeting}\n\n{result}\n\n{tip}"
-  },
-  "agent": {
-    "en": "{greeting}\n\n{result}\n\n{tip}",
-    "zh": "{greeting}\n\n{result}\n\n{tip}"
-  },
-  "guidance": {
-    "subject": {
-      "en": "Re: {originalSubject}",
-      "zh": "Re: {originalSubject}"
-    },
-    "body": {
-      "en": "{greeting}\n\nThanks for reaching out! Here's how to use this agent:\n\n[Explain the primary usage — e.g. forward an email to get X]\n\n— aInbox",
-      "zh": "{greeting}\n\n感谢联系！以下是使用方法：\n\n[说明主要用法 — 例如转发邮件即可获得 X]\n\n— aInbox"
-    }
-  },
-  "error": {
-    "subject": {
-      "en": "Re: {originalSubject}",
-      "zh": "Re: {originalSubject}"
-    },
-    "body": {
-      "en": "{greeting}\n\nSorry, something went wrong while processing your email. Please try again in a few minutes.\n\nIf this keeps happening, let us know at {feedbackEmail}.\n\n— aInbox",
-      "zh": "{greeting}\n\n抱歉，处理您的邮件时出现了问题。请稍后重试。\n\n如果问题持续出现，请联系 {feedbackEmail}。\n\n— aInbox"
-    }
-  },
-  "rateLimit": {
-    "subject": {
-      "en": "[aInbox] Daily limit reached",
-      "zh": "[aInbox] 今日额度已用完"
-    },
-    "body": {
-      "en": "{greeting}\n\nYou've used all {limit} requests for today. Your limit resets in about {hoursLeft}h.\n\naInbox is free during beta — we'll increase limits as we grow.\n\nFeedback? {feedbackEmail}",
-      "zh": "{greeting}\n\n你今天的 {limit} 条请求额度已全部用完，约 {hoursLeft} 小时后重置。\n\naInbox 公测期间免费 — 随着发展我们会提高额度。\n\n反馈？{feedbackEmail}"
-    }
   }
 }

--- a/draft/assets/templates.json
+++ b/draft/assets/templates.json
@@ -10,39 +10,5 @@
   "draft": {
     "en": "{greeting}\n\nHere's your draft:\n\n------\n{result}\n------\n\n{tip}",
     "zh": "{greeting}\n\n以下是为您起草的内容：\n\n------\n{result}\n------\n\n{tip}"
-  },
-  "agent": {
-    "en": "{greeting}\n\n{result}\n\n{tip}",
-    "zh": "{greeting}\n\n{result}\n\n{tip}"
-  },
-  "guidance": {
-    "subject": {
-      "en": "Re: {originalSubject}",
-      "zh": "Re: {originalSubject}"
-    },
-    "body": {
-      "en": "{greeting}\n\nI'm aInbox Draft — I help you write emails, replies, and messages.\n\nJust email me at draft@ainbox.io and describe what you need. For example:\n- \"Write a polite decline for a meeting invite\"\n- \"Draft a follow-up to a client about a delayed project\"\n- \"Help me reply to this complaint professionally\"\n\nI'll send back a ready-to-use draft. Reply to refine it until it's perfect.\n\n— aInbox Draft",
-      "zh": "{greeting}\n\n我是 aInbox Draft — 帮你撰写邮件、回复和各类消息。\n\n只需发邮件到 draft@ainbox.io，描述你需要写什么。例如：\n- \"帮我写一封礼貌拒绝会议邀请的邮件\"\n- \"帮我写一封跟进客户项目延期的邮件\"\n- \"帮我专业地回复这个投诉\"\n\n我会回复一份可以直接使用的草稿。回复即可进一步修改，直到满意为止。\n\n— aInbox Draft"
-    }
-  },
-  "error": {
-    "subject": {
-      "en": "Re: {originalSubject}",
-      "zh": "Re: {originalSubject}"
-    },
-    "body": {
-      "en": "{greeting}\n\nSorry, something went wrong while generating your draft. Please try again in a few minutes.\n\nIf this keeps happening, let us know at {feedbackEmail}.\n\n— aInbox Draft",
-      "zh": "{greeting}\n\n抱歉，生成草稿时出现了问题。请稍后重试。\n\n如果问题持续出现，请联系 {feedbackEmail}。\n\n— aInbox Draft"
-    }
-  },
-  "rateLimit": {
-    "subject": {
-      "en": "[aInbox] Daily draft limit reached",
-      "zh": "[aInbox] 今日草稿额度已用完"
-    },
-    "body": {
-      "en": "{greeting}\n\nYou've used all {limit} drafts for today. Your limit resets in about {hoursLeft}h.\n\naInbox is free during beta — we'll increase limits as we grow.\n\nFeedback? {feedbackEmail}",
-      "zh": "{greeting}\n\n你今天的 {limit} 条草稿额度已全部用完，约 {hoursLeft} 小时后重置。\n\naInbox 公测期间免费 — 随着发展我们会提高额度。\n\n反馈？{feedbackEmail}"
-    }
   }
 }

--- a/feedback/assets/templates.json
+++ b/feedback/assets/templates.json
@@ -1,44 +1,6 @@
 {
-  "result": {
-    "en": "{greeting}\n\n{result}\n\n{tip}",
-    "zh": "{greeting}\n\n{result}\n\n{tip}"
-  },
   "feedback": {
     "en": "{greeting}\n\n{result}\n\n{tip}",
     "zh": "{greeting}\n\n{result}\n\n{tip}"
-  },
-  "agent": {
-    "en": "{greeting}\n\n{result}\n\n{tip}",
-    "zh": "{greeting}\n\n{result}\n\n{tip}"
-  },
-  "guidance": {
-    "subject": {
-      "en": "Re: {originalSubject}",
-      "zh": "Re: {originalSubject}"
-    },
-    "body": {
-      "en": "{greeting}\n\nThanks for reaching out! This is aInbox Feedback — we collect and forward feedback to the team.\n\nTo share feedback, just send an email to feedback@ainbox.io describing your experience, suggestion, or issue.\n\nLooking for other aInbox features? Forward any email to summary@ainbox.io for a summary, or draft@ainbox.io for help writing a reply.\n\n— aInbox Feedback",
-      "zh": "{greeting}\n\n感谢联系！这里是 aInbox 反馈 — 我们收集并转发反馈给团队。\n\n要分享反馈，只需发送邮件到 feedback@ainbox.io，描述您的体验、建议或问题。\n\n需要其他 aInbox 功能？将邮件转发到 summary@ainbox.io 获取摘要，或发送到 draft@ainbox.io 获取写作帮助。\n\n— aInbox Feedback"
-    }
-  },
-  "error": {
-    "subject": {
-      "en": "Re: {originalSubject}",
-      "zh": "Re: {originalSubject}"
-    },
-    "body": {
-      "en": "{greeting}\n\nSorry, something went wrong while processing your feedback. Please try again in a few minutes.\n\nIf this keeps happening, you can reach us directly at verkyyi@gmail.com.\n\n— aInbox Feedback",
-      "zh": "{greeting}\n\n抱歉，处理您的反馈时出现了问题。请稍后重试。\n\n如果问题持续出现，您可以直接联系 verkyyi@gmail.com。\n\n— aInbox Feedback"
-    }
-  },
-  "rateLimit": {
-    "subject": {
-      "en": "[aInbox] Daily feedback limit reached",
-      "zh": "[aInbox] 今日反馈额度已用完"
-    },
-    "body": {
-      "en": "{greeting}\n\nYou've sent {limit} feedback messages today. Your limit resets in about {hoursLeft}h.\n\nWe appreciate your engagement! For urgent issues, you can reach us at verkyyi@gmail.com.\n\n— aInbox Feedback",
-      "zh": "{greeting}\n\n你今天已发送 {limit} 条反馈消息，约 {hoursLeft} 小时后重置。\n\n感谢您的参与！如有紧急问题，可直接联系 verkyyi@gmail.com。\n\n— aInbox Feedback"
-    }
   }
 }

--- a/schema.json
+++ b/schema.json
@@ -13,37 +13,25 @@
       "additionalProperties": false
     },
 
+    "utilityTemplate": {
+      "type": "object",
+      "properties": {
+        "subject": { "$ref": "#/definitions/bilingualString" },
+        "body":    { "$ref": "#/definitions/bilingualString" }
+      },
+      "required": ["subject", "body"]
+    },
+
     "templatesJson": {
       "type": "object",
       "properties": {
-        "summary": { "$ref": "#/definitions/bilingualString" },
-        "agent":   { "$ref": "#/definitions/bilingualString" },
-        "guidance": {
-          "type": "object",
-          "properties": {
-            "subject": { "$ref": "#/definitions/bilingualString" },
-            "body":    { "$ref": "#/definitions/bilingualString" }
-          },
-          "required": ["subject", "body"]
-        },
-        "error": {
-          "type": "object",
-          "properties": {
-            "body": { "$ref": "#/definitions/bilingualString" }
-          },
-          "required": ["body"]
-        },
-        "rateLimit": {
-          "type": "object",
-          "properties": {
-            "subject": { "$ref": "#/definitions/bilingualString" },
-            "body":    { "$ref": "#/definitions/bilingualString" }
-          },
-          "required": ["subject", "body"]
-        }
+        "result":    { "$ref": "#/definitions/bilingualString" },
+        "agent":     { "$ref": "#/definitions/bilingualString" },
+        "guidance":  { "$ref": "#/definitions/utilityTemplate" },
+        "error":     { "$ref": "#/definitions/utilityTemplate" },
+        "rateLimit": { "$ref": "#/definitions/utilityTemplate" }
       },
-      "required": ["summary", "agent", "guidance", "error", "rateLimit"],
-      "additionalProperties": false
+      "additionalProperties": { "$ref": "#/definitions/bilingualString" }
     },
 
     "tipsJson": {

--- a/summary/assets/templates.json
+++ b/summary/assets/templates.json
@@ -2,39 +2,5 @@
   "result": {
     "en": "{greeting}\n\nBased on your forwarded email, here's a quick summary:\n\n------\n{result}\n------\n\n{tip}",
     "zh": "{greeting}\n\n以下是您转发邮件的摘要：\n\n------\n{result}\n------\n\n{tip}"
-  },
-  "agent": {
-    "en": "{greeting}\n\n{result}\n\n{tip}",
-    "zh": "{greeting}\n\n{result}\n\n{tip}"
-  },
-  "guidance": {
-    "subject": {
-      "en": "Re: {originalSubject}",
-      "zh": "Re: {originalSubject}"
-    },
-    "body": {
-      "en": "{greeting}\n\nIt looks like you sent this email directly to aInbox. Right now, aInbox works by summarizing *forwarded* emails.\n\nTo get a summary, just forward the email you want summarized to summary@ainbox.io — you'll receive a summary within seconds.\n\nDirect email summarization is coming soon — stay tuned!\n\n— aInbox",
-      "zh": "{greeting}\n\n看起来你直接发送了邮件给 aInbox。目前 aInbox 只支持摘要转发的邮件。\n\n使用方法：将你想摘要的邮件转发到 summary@ainbox.io，几秒内就能收到摘要。\n\n直接发送邮件的摘要功能即将上线，敬请期待！\n\n— aInbox"
-    }
-  },
-  "error": {
-    "subject": {
-      "en": "Re: {originalSubject}",
-      "zh": "Re: {originalSubject}"
-    },
-    "body": {
-      "en": "{greeting}\n\nSorry, something went wrong while processing your email. Please try forwarding it again in a few minutes.\n\nIf this keeps happening, let us know at {feedbackEmail}.\n\n— aInbox",
-      "zh": "{greeting}\n\n抱歉，处理您的邮件时出现了问题。请稍后重新转发这封邮件再试一次。\n\n如果问题持续出现，请联系 {feedbackEmail}。\n\n— aInbox"
-    }
-  },
-  "rateLimit": {
-    "subject": {
-      "en": "[aInbox] Daily limit reached",
-      "zh": "[aInbox] 今日额度已用完"
-    },
-    "body": {
-      "en": "{greeting}\n\nYou've used all {limit} email summaries for today. Your limit resets in about {hoursLeft}h.\n{refSection}\n\naInbox is free during beta — we'll increase limits as we grow.\n\nFeedback? {feedbackEmail}",
-      "zh": "{greeting}\n\n你今天的 {limit} 条邮件摘要额度已全部用完，约 {hoursLeft} 小时后重置。\n{refSection}\n\naInbox 公测期间免费 — 随着发展我们会提高额度。\n\n反馈？{feedbackEmail}"
-    }
   }
 }


### PR DESCRIPTION
## Summary

- **Removed utility templates** (`error`, `rateLimit`, `guidance`) from all agents — these are now provided by server-side defaults in `src/emailDefaults.json`
- **Skills only keep mode template overrides**: summary keeps `result`, draft keeps `result`/`reply-assist`/`draft`, feedback keeps `feedback`, _template keeps `result`
- **schema.json**: all template keys now optional, `additionalProperties` allows custom mode keys
- **Docs updated**: README.md and CONTRIBUTING.md reflect that `templates.json` is optional and utility templates are managed by the server

Companion to verkyyi/ainbox#18 — merge the server PR first, then this one.

## Test plan

- [x] Server tests pass with old skills (backward compatible merge logic)
- [x] Server tests pass with new stripped skills (defaults fill in utility templates)
- [ ] Manual: verify end-to-end after both PRs are deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)