### PR TITLE
Add cc@ skill and update messaging across all agents

### DIFF
--- a/cc/SKILL.md
+++ b/cc/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cc
 description: >
-  Silent inbox collector at cc@ainbox.io. CC or send to this address
+  Silent inbox collector at cc@ainbox.io. Share or send to this address
   on any email to store it for AI access via Claude MCP.
 config:
   store: true
@@ -30,7 +30,7 @@ This is the sender's very first email to cc@ainbox.io. Their account
 was just created. Send a warm, concise welcome:
 
 1. Confirm their email has been stored
-2. Explain: "CC cc@ainbox.io on any email — or send directly —
+2. Explain: "Share cc@ainbox.io on any email — or send directly —
    and it's instantly available to your AI in Claude"
 3. To connect: Add aInbox as an integration in Claude Desktop or
    claude.ai — MCP server URL: https://mcp.ainbox.io/mcp

--- a/draft/SKILL.md
+++ b/draft/SKILL.md
@@ -75,8 +75,8 @@ If the user asks how you work or what you can do, introduce yourself. Key facts:
 - Works with any email client (Gmail, Outlook, Apple Mail, Yahoo, etc.)
 - Supports multiple languages — I draft in the language you write in
 - Free during beta ({dailyLimit} drafts/day)
-- Private by design — emails are processed in real-time and never stored
-- No signup, no app, no accounts needed
+- Your data, your control — we never train models on your emails
+- No signup needed — your account is created automatically
 
 ## Drafting quality standards
 

--- a/feedback/SKILL.md
+++ b/feedback/SKILL.md
@@ -48,7 +48,7 @@ If the email is a question about aInbox or how feedback works (not actual feedba
 - Send feedback to feedback@ainbox.io — we read every message
 - Forward emails to summary@ainbox.io for summaries, or draft@ainbox.io for drafts
 - aInbox is free during beta ({dailyLimit} feedback messages/day)
-- Private by design — emails are processed in real-time and never stored
+- Your data, your control — we never train models on your emails
 
 ## General guidelines
 

--- a/summary/SKILL.md
+++ b/summary/SKILL.md
@@ -65,8 +65,8 @@ If the email was sent directly to you (not forwarded — no forwarding headers o
    - Supports multiple languages — I reply in the same language as your email
    - I detect phishing and spam and warn you automatically
    - Free during beta ({dailyLimit} summaries/day)
-   - Private by design — emails are processed in real-time and never stored
-   - No signup, no app, no accounts needed
+   - Your data, your control — we never train models on your emails
+   - No signup needed — your account is created automatically
 
 2. CONTENT TO PROCESS (articles, documents, notes, newsletters, anything substantial):
    Summarize it exactly like a forwarded email — category tag on its own line, then a blank line, followed by the summary. Apply the same summarization guidelines above.


### PR DESCRIPTION
## Summary

- **Add cc@ skill** — silent inbox collector at cc@ainbox.io, stores emails for AI access via Claude MCP, only responds to new users with a welcome message
- **Remove empty templates.json files** — no longer needed since LLM generates complete responses
- **Update messaging across all agents** — replace "Private by design — never stored" with "Your data, your control — we never train models on your emails" (emails are now stored for MCP access); update "no accounts" to reflect auto-created accounts; use "share" language in cc agent welcome

## Test plan

- [ ] Verify cc agent SKILL.md parses correctly by skillLoader
- [ ] Confirm welcome message reads naturally with "share" language
- [ ] Check summary, draft, feedback agents reflect updated data ownership messaging
- [ ] Trigger skill hot-reload and verify agents load without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)