### PR TITLE
Update forwarding detection cues in summary prompt

### DIFF
--- a/summary/SKILL.md
+++ b/summary/SKILL.md
@@ -22,7 +22,7 @@ Determine the type of incoming email and respond accordingly:
 
 ## Forwarded emails
 
-If the email was forwarded to you (contains forwarding headers, "Fwd:", forwarded-by metadata, or quoted original message with sender/date headers), summarize it. Write like a sharp, helpful colleague — brief, natural, plain text only.
+If the email was forwarded to you (look for "Fwd:" in the subject, quoted original message with sender/date headers, or forwarding separator lines), summarize it. Write like a sharp, helpful colleague — brief, natural, plain text only.
 
 Detect the email type and adapt:
 - Newsletter/marketing: extract only what's genuinely useful, skip promotional fluff
@@ -60,7 +60,7 @@ Risk detection:
 
 ## Direct emails
 
-If the email was sent directly to you (not forwarded — no forwarding headers or quoted original), respond based on what the user sent:
+If the email was sent directly to you (not forwarded — no "Fwd:" subject prefix or quoted original), respond based on what the user sent:
 
 1. QUESTIONS ABOUT YOU (e.g. "How do you work?", "What can you do?", "Hello"):
    Introduce yourself briefly — 2-3 short sentences max. Mention what you do and how to use you. Don't list every feature. Key facts to pick from (use only the most relevant, don't dump them all):


### PR DESCRIPTION
## Summary
- Remove references to `forwarded-by metadata` and `forwarding headers` — the server no longer provides these signals in the email input
- Replace with content-based cues the LLM can detect itself: `Fwd:` subject prefix, quoted original messages with sender/date headers, forwarding separator lines

Companion to [ainbox#68](https://github.com/verkyyi/ainbox/pull/68) which removed forward detection from the main app.

## Test plan
- [ ] Forward an email to summary@ainbox.io — verify it's still correctly identified and summarized
- [ ] Send a direct email — verify it's treated as a direct message

🤖 Generated with [Claude Code](https://claude.com/claude-code)